### PR TITLE
cf_map_route function for cf-cli-resource

### DIFF
--- a/assets/cf-functions.sh
+++ b/assets/cf-functions.sh
@@ -376,3 +376,9 @@ function cf_is_marketplace_service_available() {
   local plan=${2:?plan null or not set}
   cf marketplace | grep "$service_name" | grep "$plan" >/dev/null
 }
+
+function cf_map_route() {
+  local app_name=$1
+  local domain=$2
+  cf map-route ${app_name} ${domain} --hostname ${app_name}
+}

--- a/assets/out
+++ b/assets/out
@@ -272,6 +272,15 @@ echo "$params" | jq -c '.commands[]' | while read -r options; do
     printf '\e[92m[INFO]\e[0m Executing \e[33m%s\e[0m: %s\n' "$command" "$service_broker"
     cf_target "$org" "$space"
     cf_delete_service_broker "$service_broker"
+  elif [ "map-route" = "$command" ]; then
+    app_name=$(echo $options | jq -r '.app_name //empty')
+    domains=$(echo $options | jq -r '.domains[] //empty')
+    printf '\e[92m[INFO]\e[0m Executing \e[33m%s\e[0m: %s\n' "$command"
+    cf_target "$org" "$space"
+    for domain in $domains
+    do
+      cf_map_route "$app_name" "$domain"
+    done
   else
     printf '\e[91m[ERROR]\e[0m invalid payload (unknown command: %s)\n' "$command"
     exit 1


### PR DESCRIPTION
We have created a new function called cf_map_route in the cf-cli-resource that will add additional domains to a named app, in a given org and space